### PR TITLE
fix: clean up Create Lock timer arguments

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ import { Address } from "./hooks/types";
 
 export const ZERO_ADDRESS: Address = "0x0000000000000000000000000000000000000000";
 export const TOKEN_ICON = "/svg/coin.svg";
+export const HOUR = 3600;
 export const RPC_URI = import.meta.env.VITE_RPC_URI;
 export const GOVNFT_ADDRESS = import.meta.env.VITE_GOVNFT_ADDRESS;
 export const GOVNFT_SUGAR_ADDRESS = import.meta.env.VITE_GOVNFT_SUGAR_ADDRESS;

--- a/src/pages/Create/components/Creator.tsx
+++ b/src/pages/Create/components/Creator.tsx
@@ -7,12 +7,11 @@ import { useAccount } from "wagmi";
 import AssetInput from "../../../components/AssetInput";
 import FlowAllowance from "../../../components/FlowAllowance";
 import GovnftChart from "../../../components/GovnftChart";
-import { GOVNFT_ADDRESS } from "../../../constants";
+import { GOVNFT_ADDRESS, HOUR } from "../../../constants";
 import { useTokens } from "../../../hooks/token";
 import { Token } from "../../../hooks/types";
 import Checklist from "./Checklist";
 import CreateButton from "./CreateButton";
-import CreatorPreview from "./CreatorPreview";
 
 export default function Creator() {
   const [splitable, setSplitable] = useState(false);
@@ -20,7 +19,7 @@ export default function Creator() {
   const [toAddress, setToAddress] = useState(null);
   const [allowed, setAllowed] = useState(false);
 
-  const today = dayjs();
+  const today = dayjs().endOf("hour");
   const [vestingDuration, setVestingDuration] = useState(0);
   const [cliffDuration, setCliffDuration] = useState(0);
   const [selectedStartDate, setSelectedStartDate] = useState(today);
@@ -201,8 +200,8 @@ export default function Creator() {
                 token={token.address}
                 recipient={toAddress}
                 amount={amount}
-                start={BigInt(selectedStartDate.unix() + 1000)} //TODO: fix start date so not in past
-                end={BigInt(selectedStartDate.unix() + 1000000)} //TODO: use VestingDuration to calculate duration in seconds
+                start={BigInt(selectedStartDate.unix() - (selectedStartDate.unix() % HOUR) + HOUR)}
+                end={BigInt(selectedStartDate.unix() - (selectedStartDate.unix() % HOUR) + HOUR + vestingDuration)}
                 cliff={BigInt(cliffDuration)}
                 description={desc}
               />


### PR DESCRIPTION
Use the end of the current hour as `start` param to prevent reverts on the smart contracts side