### PR TITLE
Ensure links are absolute

### DIFF
--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -102,7 +102,7 @@ export default function Profile({ children }) {
   }
 
   return (
-    <NavLink href="/connect" size="sm" useButton={true}>
+    <NavLink href="~/connect" size="sm" useButton={true}>
       Connect
     </NavLink>
   );

--- a/src/pages/Connect/index.tsx
+++ b/src/pages/Connect/index.tsx
@@ -12,7 +12,7 @@ export default function Connect() {
   const [_location, navigate] = useLocation();
 
   useEffect(() => {
-    isConnected && navigate("/dash");
+    isConnected && navigate("~/dash");
   }, [isConnected, navigate]);
 
   return (

--- a/src/pages/Create/components/CreateButton.tsx
+++ b/src/pages/Create/components/CreateButton.tsx
@@ -36,7 +36,7 @@ export default function CreateButton({
       // @ts-ignore
       Toaster.toast(error);
     } else if (isConfirmed) {
-      navigate("/minted");
+      navigate("~/minted");
       Toaster.toast.success("GovNFT created!");
     }
   }, [error, isConfirmed, navigate]);


### PR DESCRIPTION
If you don't use a `~` on links with `wouter` (v3 at least), the links will be relative. I noticed a bug with this on the `Connect` button, where I was on a nested path something like `nft/7` and clicking the button directed me to `nft/connect`.

Took the opportunity and edited others just to be safe.