### PR TITLE
Add ConsoleLog Lint Warning

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,6 +8,7 @@
   "linter": {
     "enabled": true,
     "rules": {
+      "suspicious": { "noConsoleLog": "warn" },
       "a11y": {
         "useKeyWithClickEvents": "off"
       }


### PR DESCRIPTION
@eyezick this only warns about it, will not remove the console log with --apply. But i think it should be ok. Onboard?