### PR TITLE
Fix flowbite Datepicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "chart.js": "^4.4.1",
     "dayjs": "^1.11.9",
     "events": "^3.3.0",
-    "flowbite-react": "0.6.0",
+    "flowbite-react": "0.6.1",
     "lodash": "*",
     "lucide-react": "^0.276.0",
     "process": "^0.11.10",

--- a/src/pages/Create/components/Creator.tsx
+++ b/src/pages/Create/components/Creator.tsx
@@ -48,9 +48,8 @@ export default function Creator() {
   }, [tokens, tokens[0]]);
 
   const handleStartDate = useCallback(
-    (e) => {
-      //@ts-ignore
-      const selectedTime = dayjs(e.target.value);
+    (date: Date) => {
+      const selectedTime = dayjs(date);
       if (selectedTime.isBefore(today)) {
         setSelectedStartDate(today);
       } else {
@@ -99,11 +98,7 @@ export default function Creator() {
 
           <div className="space-y-3">
             <div className="text-xs text-gray-600 dark:text-gray-400">Start Date</div>
-            <Datepicker
-              // TODO: Flowbite datepicker is not working, we need to replace it
-              // @ts-ignore
-              onSelect={handleStartDate}
-            />
+            <Datepicker onSelectedDateChanged={handleStartDate} />
           </div>
 
           <div className="md:flex gap-6">

--- a/yarn.lock
+++ b/yarn.lock
@@ -3005,10 +3005,10 @@ find-up@^6.3.0:
     locate-path "^7.1.0"
     path-exists "^5.0.0"
 
-flowbite-react@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.npmjs.org/flowbite-react/-/flowbite-react-0.6.0.tgz"
-  integrity sha512-nupIRMNbCgoomIPxD/Do5FIqWHz8FQ8kkpnUQER7aZbO92AyITqT3riMwNwKc27zdbit3PY5iEvO5EXiGlmaow==
+flowbite-react@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/flowbite-react/-/flowbite-react-0.6.1.tgz#3d2b345af53ada254a4970446d04d57bddcd78f5"
+  integrity sha512-UuAdxmEx5sA8bQ7VKPvGWCY1V6j8a9RPnvBx7Hm/uqTJO8Iq3jLymAgC3uTMcB21G2Qco0Euf1xXPEKuJPTgMQ==
   dependencies:
     "@floating-ui/react" "^0.24.3"
     flowbite "^1.6.6"


### PR DESCRIPTION
So it turns out the DatePicker was broken all along. The `onSelect` callback was only being called only when the input field was selected, NOT when the date was selected. 

So we were actually sending unintended start times to the contract this whole time.

Fortunately it was fixed in the next release of flow-bite and they added a new handler `onSelectedDateChanged` that fires when the date changes.