### PR TITLE
Fix vested nft statuses on dashboard

### DIFF
--- a/src/components/DateFormat.tsx
+++ b/src/components/DateFormat.tsx
@@ -4,7 +4,7 @@ import { formatUnits } from "viem";
 export default function DateFormat({
   ts,
 }: {
-  ts: Dayjs | bigint;
+  ts: Dayjs | bigint | number;
 }) {
   if (!ts) {
     return <></>;

--- a/src/components/DateFromNow.tsx
+++ b/src/components/DateFromNow.tsx
@@ -12,7 +12,7 @@ export default function DateFromNow({
   deltaDays = 0,
   tooltip = true,
 }: {
-  ts: Dayjs | bigint;
+  ts: Dayjs | bigint | number;
   prefix?: string;
   pastPrefix?: string;
   deltaDays?: number;

--- a/src/components/GovnftHeader.tsx
+++ b/src/components/GovnftHeader.tsx
@@ -31,7 +31,7 @@ export default function GovnftHeader({
           </div>
           <div className="hidden sm:flex gap-5 items-center pr-1 text-sm">
             <GovnftStatus nft={nft} />
-            <GovnftProgress vestedPct={nft.vestedPct} />
+            <GovnftProgress vestedPct={nft.vestedPct} vestingStarted={nft.vestingStarted} />
           </div>
         </div>
         <>

--- a/src/components/GovnftProgress.tsx
+++ b/src/components/GovnftProgress.tsx
@@ -4,8 +4,10 @@ import { GovNft } from "#/hooks/types";
 
 export default function GovnftProgress({
   vestedPct,
+  vestingStarted,
 }: {
   vestedPct: number;
+  vestingStarted: boolean;
 }) {
   if (vestedPct === 100) {
     return (
@@ -17,7 +19,7 @@ export default function GovnftProgress({
     );
   }
 
-  if (vestedPct === 0) {
+  if (!vestingStarted) {
     return (
       <div className="w-16 h-16 flex items-center justify-center">
         <div className="p-5 rounded-full border-[3px] border-gray-100 dark:border-gray-950/30 text-amber-600 flex items-center justify-center">

--- a/src/components/GovnftStatus.tsx
+++ b/src/components/GovnftStatus.tsx
@@ -18,13 +18,13 @@ export default function GovnftStatus({
   return (
     <div className="flex flex-col justify-center items-end rounded-md">
       <div className="flex gap-3 items-center">
-        {nft.vestedPct === 0 && (
+        {!nft.vestingStarted && (
           <div className="flex gap-2.5 items-center">
             <div className="w-1.5 h-1.5 bg-amber-600 rounded-full animate-pulse" />
             <DateFormat ts={nft.start} />
           </div>
         )}
-        {nft.vestedPct !== 0 && (
+        {nft.vestingStarted && (
           <div className="flex gap-2.5 items-center">
             <div className="w-1.5 h-1.5 bg-green-500 rounded-full" />
             <DateFormat ts={nft.end} />
@@ -32,12 +32,12 @@ export default function GovnftStatus({
         )}
       </div>
 
-      {nft.vestedPct === 0 && (
+      {!nft.vestingStarted && (
         <div className="text-amber-600 pt-1.5 text-xs">
           <DateFromNow ts={nft.start} prefix="vesting starts in" tooltip={false} />
         </div>
       )}
-      {nft.vestedPct !== 0 && (
+      {nft.vestingStarted && (
         <div className="text-gray-600 dark:text-gray-400 pt-1.5 text-xs">
           <DateFromNow ts={nft.end} prefix="vesting ends in" pastPrefix="vesting ended" tooltip={false} />
         </div>

--- a/src/hooks/govnft.ts
+++ b/src/hooks/govnft.ts
@@ -7,15 +7,16 @@ import type { Address, GovNft } from "./types";
 
 import { GOVNFT_SUGAR_ABI, GOVNFT_SUGAR_ADDRESS } from "#/constants";
 
-function postFetch(nft, account: Address) {
+function postFetch(nft, account: Address): GovNft {
   const vestedPct = Math.trunc(
     100 - (Number(formatUnits(nft.amount, 0)) / Number(formatUnits(nft.total_locked, 0))) * 100,
   );
+  const vestingStarted = nft.start * 1000 <= Date.now();
 
   const isOwner = nft.owner.toLowerCase() === account.toLowerCase();
   const isMinter = nft.minter.toLowerCase() === account.toLowerCase();
   const isDelegated = nft.delegated.toLowerCase() !== ZERO_ADDRESS;
-  return { ...nft, isOwner, isMinter, isDelegated, vestedPct, name: "" };
+  return { ...nft, isOwner, isMinter, isDelegated, vestedPct, name: "", vestingStarted };
 }
 
 async function fetchMintedNfts(account: Address, collection: Address): Promise<GovNft[]> {

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -18,7 +18,7 @@ export type GovNft = {
   claimable: bigint;
   split_count: bigint;
   cliff_length: bigint;
-  start: bigint;
+  start: number;
   end: bigint;
   token: Address;
   vault: Address;
@@ -26,7 +26,8 @@ export type GovNft = {
   owner: Address;
   address: Address; // address of the collection
   delegated: Address;
-  // Total amount vested in percentanges
+  vestingStarted: boolean;
+  // Total amount vested in percentage (decimals truncated)
   vestedPct: number;
   isOwner: boolean;
   isMinter: boolean;

--- a/src/pages/Create/components/Creator.tsx
+++ b/src/pages/Create/components/Creator.tsx
@@ -204,7 +204,7 @@ export default function Creator() {
                 token={token.address}
                 recipient={toAddress}
                 amount={amount}
-                start={BigInt(selectedStartDate.unix() + 1000)}
+                start={BigInt(selectedStartDate.unix())}
                 end={BigInt(selectedStartDate.unix() + vestingDuration)}
                 cliff={BigInt(cliffDuration)}
                 description={description}

--- a/src/pages/Dashboard/components/Govnft.tsx
+++ b/src/pages/Dashboard/components/Govnft.tsx
@@ -33,7 +33,7 @@ export default function Govnft({
         <div className="flex gap-4 items-center">
           <div className="hidden lg:flex gap-5 items-center pr-3">
             <GovnftStatus nft={nft} />
-            <GovnftProgress vestedPct={nft.vestedPct} />
+            <GovnftProgress vestedPct={nft.vestedPct} vestingStarted={nft.vestingStarted} />
           </div>
           <div className="px-6 py-2 w-52 hidden xl:flex flex-col gap-2 justify-center items-end border-l border-gray-100 dark:border-gray-950/20">
             <div className="text-gray-400 dark:text-gray-600 text-xs">Locked</div>


### PR DESCRIPTION
This fixes two issues:

1. The start time was hardcoded to always be an additional ~16 minutes (1000 seconds) which would be noticeable if you picked a start time of today (now). Deleted this.
2. The vestedPct truncates all decimals, so it shows as `0` at times when it truly is already is vesting a small fraction. This creates a confusing experience if early in the vesting as we were using this var to check if vesting began. Introduced a new boolean based off the start time.