### PR TITLE
Preserve query params on top navigation

### DIFF
--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -1,9 +1,9 @@
 import { Button } from "flowbite-react";
-import { useLocation } from "wouter";
+import { useSearchParams } from "#/hooks/searchParams";
 
 export default function NavLink({ href, children, useButton = false, ...opts }) {
   const LinkComponent = useButton ? Button : "a";
-  const [_location, navigate] = useLocation();
+  const [, , navigate] = useSearchParams();
   const goTo = (event, ref) => {
     if (navigate) {
       event.preventDefault();

--- a/src/hooks/govnft.ts
+++ b/src/hooks/govnft.ts
@@ -61,7 +61,7 @@ export function useMintedNfts(accountAddress: Address, collection: Address, opts
 
 export function useOwnedNfts(accountAddress: Address, collection: Address, opts = {}) {
   return useQuery({
-    queryKey: ["fetchOwnedNfts"],
+    queryKey: ["fetchOwnedNfts", collection],
     queryFn: () => fetchOwnedNfts(accountAddress, collection),
     enabled: !!collection,
     ...opts,

--- a/src/hooks/searchParams.ts
+++ b/src/hooks/searchParams.ts
@@ -14,5 +14,13 @@ export function useSearchParams() {
     [location, navigate],
   );
 
-  return [searchParams, setSearchParams] as const;
+  const handleNavigate = useCallback(
+    (href: string, preserveParams = true) => {
+      const params = preserveParams ? `?${search}` : "";
+      navigate(`${href}${params}`);
+    },
+    [navigate, search],
+  );
+
+  return [searchParams, setSearchParams, handleNavigate] as const;
 }


### PR DESCRIPTION
This is to fix where navigating with `NavLink` does not preserve any query params.

I've taken a look and it seems https://github.com/molefrog/wouter does not provide an API for this.