### PR TITLE
Preserve params for all navigations

### DIFF
--- a/src/pages/Create/components/CreateButton.tsx
+++ b/src/pages/Create/components/CreateButton.tsx
@@ -1,10 +1,10 @@
 import { Button } from "flowbite-react";
 import { useEffect } from "react";
 import { useWaitForTransactionReceipt, useWriteContract } from "wagmi";
-import { useLocation } from "wouter";
 import Toaster from "#/components/Toaster";
 import { GOVNFT_ABI } from "#/constants";
 import { useCollection } from "#/hooks/collection";
+import { useSearchParams } from "#/hooks/searchParams";
 import type { Address } from "#/hooks/types";
 
 export default function CreateButton({
@@ -25,7 +25,7 @@ export default function CreateButton({
   description: string;
 }) {
   const collection = useCollection();
-  const [, navigate] = useLocation();
+  const [, , navigate] = useSearchParams();
   const { data: hash, error, isPending, writeContract } = useWriteContract();
 
   const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransactionReceipt({

--- a/src/pages/Delegate/components/DelegateButton.tsx
+++ b/src/pages/Delegate/components/DelegateButton.tsx
@@ -1,14 +1,14 @@
 import { Button } from "flowbite-react";
 import { useEffect } from "react";
 import { useWaitForTransactionReceipt, useWriteContract } from "wagmi";
-import { useLocation } from "wouter";
 
 import Toaster from "#/components/Toaster";
 import { GOVNFT_ABI } from "#/constants";
+import { useSearchParams } from "#/hooks/searchParams";
 import type { Address, GovNft } from "#/hooks/types";
 
 export default function DelegateButton({ nft, delegatee }: { nft: GovNft; delegatee: Address }) {
-  const [, navigate] = useLocation();
+  const [, , navigate] = useSearchParams();
   const { data: hash, error, isPending, writeContract } = useWriteContract();
 
   const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransactionReceipt({
@@ -20,10 +20,10 @@ export default function DelegateButton({ nft, delegatee }: { nft: GovNft; delega
       // @ts-ignore
       Toaster.toast(error);
     } else if (isConfirmed) {
-      navigate(`/nft/${nft.id}?collection=${nft.address}`);
+      navigate(`/nft/${nft.id}`);
       Toaster.toast.success("GovNFT delegated!");
     }
-  }, [error, isConfirmed, navigate, nft.id, nft.address]);
+  }, [error, isConfirmed, navigate, nft.id]);
 
   return (
     <>

--- a/src/pages/Split/components/SplitButton.tsx
+++ b/src/pages/Split/components/SplitButton.tsx
@@ -1,10 +1,10 @@
 import { Button } from "flowbite-react";
 import { useEffect } from "react";
 import { useWaitForTransactionReceipt, useWriteContract } from "wagmi";
-import { useLocation } from "wouter";
 
 import Toaster from "#/components/Toaster";
 import { DEFAULT_CHAIN, GOVNFT_ABI } from "#/constants";
+import { useSearchParams } from "#/hooks/searchParams";
 import type { Address, GovNft } from "#/hooks/types";
 
 export default function SplitButton({
@@ -24,7 +24,7 @@ export default function SplitButton({
   cliff: bigint;
   description: string;
 }) {
-  const [, navigate] = useLocation();
+  const [, , navigate] = useSearchParams();
   const { data: hash, error, isPending, writeContract } = useWriteContract();
   const { isSuccess: isConfirmed } = useWaitForTransactionReceipt({ hash });
 
@@ -34,9 +34,9 @@ export default function SplitButton({
       Toaster.toast(error);
     } else if (isConfirmed) {
       Toaster.toast.success(`Lock #${nft.id} split to ${recipient}`);
-      navigate(`/nft/${nft.id}?collection=${nft.address}`);
+      navigate(`/nft/${nft.id}`);
     }
-  }, [error, isConfirmed, navigate, recipient, nft.id, nft.address]);
+  }, [error, isConfirmed, navigate, recipient, nft.id]);
 
   return (
     <Button

--- a/src/pages/Transfer/components/TransferButton.tsx
+++ b/src/pages/Transfer/components/TransferButton.tsx
@@ -2,15 +2,15 @@ import { Button } from "flowbite-react";
 import { useEffect } from "react";
 import { useWaitForTransactionReceipt, useWriteContract } from "wagmi";
 import { useAccount } from "wagmi";
-import { useLocation } from "wouter";
 import { GOVNFT_ABI } from "#/constants";
 import type { Address, GovNft } from "#/hooks/types";
 
 import Toaster from "#/components/Toaster";
+import { useSearchParams } from "#/hooks/searchParams";
 
 export default function TransferButton({ nft, recipient }: { nft: GovNft; recipient: Address }) {
   const { address } = useAccount();
-  const [, navigate] = useLocation();
+  const [, , navigate] = useSearchParams();
   const { data: hash, error, isPending, writeContract } = useWriteContract();
 
   const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransactionReceipt({
@@ -22,10 +22,10 @@ export default function TransferButton({ nft, recipient }: { nft: GovNft; recipi
       // @ts-ignore
       Toaster.toast(error);
     } else if (isConfirmed) {
-      navigate(`/dash?collection=${nft.address}`);
+      navigate("/dash");
       Toaster.toast.success("GovNFT transfered!");
     }
-  }, [error, isConfirmed, navigate, nft.address]);
+  }, [error, isConfirmed, navigate]);
 
   return (
     <>


### PR DESCRIPTION
This preserves params for the redirect with the `CreateButton` and refactors the rest of the navigations backwards-compatibly so we don't have to manually add existing query params when we navigate.