### PR TITLE
Update readme with codegen and .env etherscan note

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 VITE_RPC_URI=https://optimism-rpc.publicnode.com
 # See: https://cloud.walletconnect.com
 VITE_WALLETCONNECT_PROJECT_ID=
+# See: https://docs.optimism.etherscan.io/getting-started/viewing-api-usage-statistics
 ETHERSCAN_API_KEY=
 # Default canonical collection
 VITE_GOVNFT_ADDRESS=0xB3F7411edEe6947FD97887b37169427cdE063632

--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,10 @@ who want to help with the development.
 
 Simplest way to run the UI locally:
 
+Make sure you have .env.development set up with the necessary API keys (optimistic etherscan, walletconnect) and then run
+
 ```
-git submodule update --init --recursive && yarn && yarn dev --host
+git submodule update --init --recursive && yarn && yarn codegen && yarn dev --host
 ```
 
 Before submitting the code, run
@@ -42,4 +44,5 @@ We're using the following libraries:
 The easiest way to start, is to copy the `.env.example` to `.env.development`.
 
 ## Design
+
 — [Figma] (https://www.figma.com/community/file/1392890250452830165)


### PR DESCRIPTION
This adds some missing info to the readm and .env.example files.

`yarn codegen` needs to be done before building the app locally and optimistic etherscan API token needs to be entered before codegen works.